### PR TITLE
Added Purpose ID parsing

### DIFF
--- a/vendorconsent/bitfield.go
+++ b/vendorconsent/bitfield.go
@@ -38,7 +38,7 @@ type consentBitField struct {
 	others     []byte
 }
 
-func (f *consentBitField) HasConsent(id uint16) bool {
+func (f *consentBitField) VendorConsent(id uint16) bool {
 	if id < 1 || id > f.MaxVendorID() {
 		return false
 	}

--- a/vendorconsent/bitfield_test.go
+++ b/vendorconsent/bitfield_test.go
@@ -15,7 +15,6 @@ func TestBitField(t *testing.T) {
 	// cmpVersion = 2
 	// consentScreen = 7
 	// consentLanguage = "en" (binary 000100001101)
-	// purposeIdBitString = 111011101001101010110011
 	consent, err := Parse(decode(t, "BONV8oqONXwgmADACHENAO7pqzAAppY"))
 	if err != nil {
 		t.Fatalf("Failed to parse valid consent string: %v", err)
@@ -24,18 +23,15 @@ func TestBitField(t *testing.T) {
 	assertUInt16sEqual(t, 14, consent.VendorListVersion())
 	assertUInt16sEqual(t, 10, consent.MaxVendorID())
 
-	var s struct{}
-	hasConsent := map[uint16]struct{}{
-		1:  s,
-		2:  s,
-		4:  s,
-		7:  s,
-		9:  s,
-		10: s,
+	purposesAllowed := buildMap(1, 2, 3, 5, 6, 7, 9, 12, 13, 15, 17, 19, 20, 23, 24)
+	for i := uint8(1); i <= 24; i++ {
+		_, ok := purposesAllowed[uint(i)]
+		assertBoolsEqual(t, ok, consent.PurposeAllowed(i))
 	}
 
+	vendorsWithConsent := buildMap(1, 2, 4, 7, 9, 10)
 	for i := uint16(1); i <= consent.MaxVendorID(); i++ {
-		_, ok := hasConsent[i]
-		assertBoolsEqual(t, ok, consent.HasConsent(i))
+		_, ok := vendorsWithConsent[uint(i)]
+		assertBoolsEqual(t, ok, consent.VendorConsent(i))
 	}
 }

--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -19,6 +19,12 @@ type VendorConsents interface {
 	// This is the upper bound (inclusive) on valid inputs for HasConsent(id).
 	MaxVendorID() uint16
 
+	// Determine if the user has consented to use data for the given Purpose.
+	//
+	// Note that the Consent string only has room for at most 24 purposes... so the return value on inputs
+	// which are greater than 24 is undefined.
+	PurposeAllowed(id uint8) bool
+
 	// Determine if a given vendor has consent to collect or receive user info.
 	//
 	// This function's behavior is undefined for "invalid" IDs.
@@ -27,7 +33,7 @@ type VendorConsents interface {
 	//
 	// It is the caller's responsibility to get the right Vendor List version for the semantics of the ID.
 	// For more information, see VendorListVersion().
-	HasConsent(id uint16) bool
+	VendorConsent(id uint16) bool
 }
 
 // Parse the vendor consent data from the string. This string should *not* be encoded (by base64 or any other encoding).

--- a/vendorconsent/consent_test.go
+++ b/vendorconsent/consent_test.go
@@ -117,3 +117,12 @@ func assertBoolsEqual(t *testing.T, expected bool, actual bool) {
 		t.Errorf("Bools were not equal. Expected %t, actual %t", expected, actual)
 	}
 }
+
+func buildMap(keys ...uint) map[uint]struct{} {
+	var s struct{}
+	m := make(map[uint]struct{}, len(keys))
+	for _, key := range keys {
+		m[key] = s
+	}
+	return m
+}

--- a/vendorconsent/metadata.go
+++ b/vendorconsent/metadata.go
@@ -47,3 +47,9 @@ func (c consentMetadata) MaxVendorID() uint16 {
 	rightByte := byte((c[20]&0x0f)<<4 + (c[21]&0xf0)>>4)
 	return binary.BigEndian.Uint16([]byte{leftByte, rightByte})
 }
+
+func (c consentMetadata) PurposeAllowed(id uint8) bool {
+	// Purposes are stored in bits 132 - 155. The interface contract only defines behavior for ints in the range [1, 24]...
+	// so in the valid range, this won't even overflow a uint8.
+	return isSet(c, uint(id+131))
+}

--- a/vendorconsent/rangesection.go
+++ b/vendorconsent/rangesection.go
@@ -118,7 +118,7 @@ type rangeSection struct {
 }
 
 // VendorConsents implementation
-func (p rangeSection) HasConsent(id uint16) bool {
+func (p rangeSection) VendorConsent(id uint16) bool {
 	if id < 1 || id > p.MaxVendorID() {
 		return false
 	}

--- a/vendorconsent/rangesection_test.go
+++ b/vendorconsent/rangesection_test.go
@@ -17,7 +17,6 @@ func TestRangeSectionConsent(t *testing.T) {
 	// cmpVersion = 2
 	// consentScreen = 7
 	// consentLanguage = "en" (binary 000100001101)
-	// purposeIdBitString = 001011010010110101101011
 	consent, err := Parse(decode(t, "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw"))
 	if err != nil {
 		t.Fatalf("Failed to parse valid consent string: %v", err)
@@ -26,36 +25,16 @@ func TestRangeSectionConsent(t *testing.T) {
 	assertUInt16sEqual(t, 14, consent.VendorListVersion())
 	assertUInt16sEqual(t, 112, consent.MaxVendorID())
 
-	var s struct{}
-	lackingConsent := map[uint16]struct{}{
-		2:  s,
-		4:  s,
-		10: s,
-		11: s,
-		12: s,
-		13: s,
-		14: s,
-		15: s,
-		16: s,
-		17: s,
-		18: s,
-		19: s,
-		20: s,
-		21: s,
-		22: s,
-		23: s,
-		24: s,
-		25: s,
-		30: s,
-		31: s,
-		32: s,
-		33: s,
-		46: s,
+	purposesWithConsent := buildMap(3, 5, 6, 8, 11, 13, 14, 16, 18, 19, 21, 23, 24)
+	for i := uint8(1); i <= 24; i++ {
+		_, ok := purposesWithConsent[uint(i)]
+		assertBoolsEqual(t, ok, consent.PurposeAllowed(i))
 	}
 
+	vendorsLackingConsent := buildMap(2, 4, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 46)
 	for i := uint16(1); i <= consent.MaxVendorID(); i++ {
-		_, ok := lackingConsent[i]
-		assertBoolsEqual(t, !ok, consent.HasConsent(i))
+		_, ok := vendorsLackingConsent[uint(i)]
+		assertBoolsEqual(t, !ok, consent.VendorConsent(i))
 	}
 }
 


### PR DESCRIPTION
Also includes some test cleanups and a method rename.

Method rename is because `HasConsent` is ambiguous when the APIs include both `Vendors` and `Purposes`.