### PR TITLE
Added constants for Purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ package main
 import (
   "log"
 
+  "github.com/prebid/go-gdpr/consentconstants"
   "github.com/prebid/go-gdpr/vendorconsent"
 )
 
@@ -43,6 +44,7 @@ import (
   "log"
   "net/http"
 
+  "github.com/prebid/go-gdpr/consentconstants"
   "github.com/prebid/go-gdpr/vendorlist"
 )
 
@@ -57,8 +59,8 @@ func DemoVendorListParsing() {
   if vendor == nil {
     log.Print("Vendor 3 did not exist in the list.")
   } else {
-    log.Printf("Vendor 3 claimed a legitimate interest for Purpose 3? %t", vendor.LegitimateInterest(3))
-    log.Printf("Vendor 3 was used for Purpose 1? %t", vendor.Purpose(1))
+    log.Printf("Vendor 3 claimed a legitimate interest for ad selection, delivery, and reporting? %t", vendor.LegitimateInterest(consentconstants.AdSelectionDeliveryReporting))
+    log.Printf("Did Vendor 3 claim to store or retrieve info? %t", vendor.Purpose(consentconstants.InfoStorageAccess))
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ import (
 )
 
 func DemoConsentStringParsing() {
-  consentString := "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw"
-  data, _ := base64.RawURLEncoding.DecodeString(encodedString)
+	encodedString := "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw"
+	data, _ := base64.RawURLEncoding.DecodeString(encodedString)
 
-  consent, err := vendorconsent.Parse(data)
-  if err != nil {
-    log.Printf("Data was not a valid consent string: %v", err)
-    return
-  }
+	consent, err := vendorconsent.Parse(data)
+	if err != nil {
+		log.Printf("Data was not a valid consent string: %v", err)
+		return
+	}
 
-  log.Printf("There are %d vendors in this consent string.", consent.MaxVendorID())
-  log.Printf("This consent string refers to version %d of the Global Vendor List.", consent.VendorListVersion())
-  log.Printf("Vendor %d has the user's consent? %t", 3, consent.HasConsent(3))
+	log.Printf("There are %d vendors in this consent string.", consent.MaxVendorID())
+	log.Printf("This consent string refers to version %d of the Global Vendor List.", consent.VendorListVersion())
+	log.Printf("Vendor %d has the user's consent? %t", 3, consent.VendorConsent(3))
 }
 ```
 
@@ -52,7 +52,7 @@ func DemoVendorListParsing() {
   resp, _ := http.Get("https://vendorlist.consensu.org/vendorlist.json")
   data, _ := ioutil.ReadAll(resp.Body)
 
-  vendors := ParseLazily(data)
+  vendors := vendorlist.ParseLazily(data)
   log.Printf("The Vendor List Version is %d.", vendors.Version())
 
   vendor := vendors.Vendor(3)

--- a/consentconstants/purposes.go
+++ b/consentconstants/purposes.go
@@ -1,0 +1,41 @@
+package consentconstants
+
+// Purpose is one of the IAB GDPR purposes. These appear in:
+//   1. `root.purposes[i]` of the vendor list: https://vendorlist.consensu.org/vendorlist.json
+//   2. PurposesAllowed of the Consent string: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-
+type Purpose uint8
+
+const (
+	// InfoStorageAccess includes the storage of information, or access to information that is already stored,
+	// on your device such as advertising identifiers, device identifiers, cookies, and similar technologies.
+	InfoStorageAccess Purpose = 1
+
+	// Personalization includes the collection and processing of information about your use of this service to subsequently personalise
+	// advertising and/or content for you in other contexts, such as on other websites or apps, over time.
+	// Typically, the content of the site or app is used to make inferences about your interests, which inform
+	// future selection of advertising and/or content.
+	Personalization Purpose = 2
+
+	// AdSelectionDeliveryReporting includes the collection of information, and combination with previously collected information, to select and deliver
+	// advertisements for you, and to measure the delivery and effectiveness of such advertisements. This includes using previously
+	// collected information about your interests to select ads, processing data about what advertisements were shown, how often they were shown,
+	// when and where they were shown, and whether you took any action related to the advertisement, including for example clicking an ad or making a purchase.
+	// This does not include personalisation, which is the collection and processing of information about your use of this service to
+	// subsequently personalise advertising and/or content for you in other contexts, such as websites or apps, over time.
+	AdSelectionDeliveryReporting Purpose = 3
+
+	// ContentSelectionDeliveryReporting includes the collection of information, and combination with previously collected information, to select and deliver
+	// content for you, and to measure the delivery and effectiveness of such content. This includes using previously
+	// collected information about your interests to select content, processing data about what content was shown,
+	// how often or how long it was shown, when and where it was shown, and whether the you took any action related to
+	// the content, including for example clicking on content. This does not include personalisation, which is the collection
+	// and processing of information about your use of this service to subsequently personalise content and/or advertising
+	// for you in other contexts, such as websites or apps, over time.
+	ContentSelectionDeliveryReporting Purpose = 4
+
+	// Measurement includes the collection of information about your use of the content, and combination with previously collected information,
+	// used to measure, understand, and report on your usage of the service. This does not include personalisation, the
+	// collection of information about your use of this service to subsequently personalise content and/or advertising
+	// for you in other contexts, i.e. on other service, such as websites or apps, over time.
+	Measurement Purpose = 5
+)

--- a/vendorconsent/bitfield_test.go
+++ b/vendorconsent/bitfield_test.go
@@ -1,6 +1,10 @@
 package vendorconsent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/prebid/go-gdpr/consentconstants"
+)
 
 func TestBitField(t *testing.T) {
 	// String built using http://acdn.adnxs.com/cmp/docs/#/tools/vendor-cookie-encoder
@@ -26,7 +30,7 @@ func TestBitField(t *testing.T) {
 	purposesAllowed := buildMap(1, 2, 3, 5, 6, 7, 9, 12, 13, 15, 17, 19, 20, 23, 24)
 	for i := uint8(1); i <= 24; i++ {
 		_, ok := purposesAllowed[uint(i)]
-		assertBoolsEqual(t, ok, consent.PurposeAllowed(i))
+		assertBoolsEqual(t, ok, consent.PurposeAllowed(consentconstants.Purpose(i)))
 	}
 
 	vendorsWithConsent := buildMap(1, 2, 4, 7, 9, 10)

--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -1,5 +1,7 @@
 package vendorconsent
 
+import "github.com/prebid/go-gdpr/consentconstants"
+
 // VendorConsents is a GDPR Vendor Consent string, as defined by IAB Europe. For technical details,
 // see https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-
 type VendorConsents interface {
@@ -23,7 +25,7 @@ type VendorConsents interface {
 	//
 	// Note that the Consent string only has room for at most 24 purposes... so the return value on inputs
 	// which are greater than 24 is undefined.
-	PurposeAllowed(id uint8) bool
+	PurposeAllowed(id consentconstants.Purpose) bool
 
 	// Determine if a given vendor has consent to collect or receive user info.
 	//

--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -23,8 +23,8 @@ type VendorConsents interface {
 
 	// Determine if the user has consented to use data for the given Purpose.
 	//
-	// Note that the Consent string only has room for at most 24 purposes... so the return value on inputs
-	// which are greater than 24 is undefined.
+	// If the purpose is converted from an int > 24, the return value is undefined because
+	// the consent string doesn't have room for more purposes than that.
 	PurposeAllowed(id consentconstants.Purpose) bool
 
 	// Determine if a given vendor has consent to collect or receive user info.

--- a/vendorconsent/metadata.go
+++ b/vendorconsent/metadata.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
+	"github.com/prebid/go-gdpr/consentconstants"
 )
 
 // Parse the metadata from the consent string.
@@ -48,8 +50,8 @@ func (c consentMetadata) MaxVendorID() uint16 {
 	return binary.BigEndian.Uint16([]byte{leftByte, rightByte})
 }
 
-func (c consentMetadata) PurposeAllowed(id uint8) bool {
+func (c consentMetadata) PurposeAllowed(id consentconstants.Purpose) bool {
 	// Purposes are stored in bits 132 - 155. The interface contract only defines behavior for ints in the range [1, 24]...
 	// so in the valid range, this won't even overflow a uint8.
-	return isSet(c, uint(id+131))
+	return isSet(c, uint(id)+131)
 }

--- a/vendorconsent/rangesection_test.go
+++ b/vendorconsent/rangesection_test.go
@@ -2,6 +2,8 @@ package vendorconsent
 
 import (
 	"testing"
+
+	"github.com/prebid/go-gdpr/consentconstants"
 )
 
 func TestRangeSectionConsent(t *testing.T) {
@@ -28,7 +30,7 @@ func TestRangeSectionConsent(t *testing.T) {
 	purposesWithConsent := buildMap(3, 5, 6, 8, 11, 13, 14, 16, 18, 19, 21, 23, 24)
 	for i := uint8(1); i <= 24; i++ {
 		_, ok := purposesWithConsent[uint(i)]
-		assertBoolsEqual(t, ok, consent.PurposeAllowed(i))
+		assertBoolsEqual(t, ok, consent.PurposeAllowed(consentconstants.Purpose(i)))
 	}
 
 	vendorsLackingConsent := buildMap(2, 4, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 46)

--- a/vendorlist/eager-parsing.go
+++ b/vendorlist/eager-parsing.go
@@ -3,6 +3,8 @@ package vendorlist
 import (
 	"encoding/json"
 	"errors"
+
+	"github.com/prebid/go-gdpr/consentconstants"
 )
 
 // ParseEagerly interprets and validates the Vendor List data up front, before returning it.
@@ -79,7 +81,7 @@ type parsedVendor struct {
 	legitimateInterestIDs map[uint8]struct{}
 }
 
-func (l parsedVendor) Purpose(purposeID uint8) (hasPurpose bool) {
+func (l parsedVendor) Purpose(purposeID consentconstants.Purpose) (hasPurpose bool) {
 	_, hasPurpose = l.purposeIDs[purposeID]
 	return
 }
@@ -88,7 +90,7 @@ func (l parsedVendor) Purpose(purposeID uint8) (hasPurpose bool) {
 // use data for the given purpose.
 //
 // For an explanation of legitimate interest, see https://www.gdpreu.org/the-regulation/key-concepts/legitimate-interest/
-func (l parsedVendor) LegitimateInterest(purposeID uint8) (hasLegitimateInterest bool) {
+func (l parsedVendor) LegitimateInterest(purposeID consentconstants.Purpose) (hasLegitimateInterest bool) {
 	_, hasLegitimateInterest = l.legitimateInterestIDs[purposeID]
 	return
 }

--- a/vendorlist/eager-parsing.go
+++ b/vendorlist/eager-parsing.go
@@ -50,11 +50,11 @@ func parseVendor(contract vendorListVendorContract) parsedVendor {
 	return parsed
 }
 
-func mapify(input []uint8) map[uint8]struct{} {
-	m := make(map[uint8]struct{}, len(input))
+func mapify(input []uint8) map[consentconstants.Purpose]struct{} {
+	m := make(map[consentconstants.Purpose]struct{}, len(input))
 	var s struct{}
 	for _, value := range input {
-		m[value] = s
+		m[consentconstants.Purpose(value)] = s
 	}
 	return m
 }
@@ -77,8 +77,8 @@ func (l parsedVendorList) Vendor(vendorID uint16) Vendor {
 }
 
 type parsedVendor struct {
-	purposeIDs            map[uint8]struct{}
-	legitimateInterestIDs map[uint8]struct{}
+	purposeIDs            map[consentconstants.Purpose]struct{}
+	legitimateInterestIDs map[consentconstants.Purpose]struct{}
 }
 
 func (l parsedVendor) Purpose(purposeID consentconstants.Purpose) (hasPurpose bool) {

--- a/vendorlist/lazy-parsing.go
+++ b/vendorlist/lazy-parsing.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/buger/jsonparser"
+	"github.com/prebid/go-gdpr/consentconstants"
 )
 
 // ParseLazily returns a view of the data which re-calculates things on each function call.
@@ -45,11 +46,11 @@ func (l lazyVendorList) Vendor(vendorID uint16) Vendor {
 
 type lazyVendor []byte
 
-func (l lazyVendor) Purpose(purposeID uint8) bool {
+func (l lazyVendor) Purpose(purposeID consentconstants.Purpose) bool {
 	return idExists(l, int(purposeID), "purposeIds")
 }
 
-func (l lazyVendor) LegitimateInterest(purposeID uint8) bool {
+func (l lazyVendor) LegitimateInterest(purposeID consentconstants.Purpose) bool {
 	return idExists(l, int(purposeID), "legIntPurposeIds")
 }
 

--- a/vendorlist/vendorlist.go
+++ b/vendorlist/vendorlist.go
@@ -1,5 +1,7 @@
 package vendorlist
 
+import "github.com/prebid/go-gdpr/consentconstants"
+
 // VendorList is an interface used to fetch information about an IAB Global Vendor list.
 // For the latest version, see: https://vendorlist.consensu.org/vendorlist.json
 type VendorList interface {
@@ -19,11 +21,11 @@ type VendorList interface {
 // Vendor describes which purposes a given vendor claims to use data for, in this vendor list.
 type Vendor interface {
 	// Purpose returns true if this vendor claims to use data for the given purpose, or false otherwise
-	Purpose(purposeID uint8) bool
+	Purpose(purposeID consentconstants.Purpose) bool
 
 	// LegitimateInterest retursn true if this vendor claims a "Legitimate Interest" to
 	// use data for the given purpose.
 	//
 	// For an explanation of legitimate interest, see https://www.gdpreu.org/the-regulation/key-concepts/legitimate-interest/
-	LegitimateInterest(purposeID uint8) bool
+	LegitimateInterest(purposeID consentconstants.Purpose) bool
 }


### PR DESCRIPTION
Pulled these from the latest version of https://vendorlist.consensu.org/vendorlist.json

There are `Purposes` and `Features`, but... we're only using `Purposes` in the APIs that exist today.