### PR TITLE
VendorListVersion bugfix

### DIFF
--- a/vendorconsent/metadata.go
+++ b/vendorconsent/metadata.go
@@ -38,7 +38,8 @@ func (c consentMetadata) Version() uint8 {
 }
 
 func (c consentMetadata) VendorListVersion() uint16 {
-	rightByte := c[16] & 0xf0 >> 4
+	// The vendor list version is stored in bits 120 - 131
+	rightByte := ((c[16] & 0xf0) >> 4) | ((c[15] & 0x0f) << 4)
 	leftByte := c[15] >> 4
 	return binary.BigEndian.Uint16([]byte{leftByte, rightByte})
 }

--- a/vendorconsent/metadata_test.go
+++ b/vendorconsent/metadata_test.go
@@ -1,0 +1,12 @@
+package vendorconsent
+
+import "testing"
+
+func TestLargeVendorListVersion(t *testing.T) {
+	consent, err := Parse(decode(t, "BON96hFON96hFABABBAA4yAAAAAAEA"))
+	if err != nil {
+		t.Fatalf("Failed to parse valid consent string: %v", err)
+	}
+
+	assertUInt16sEqual(t, 3634, consent.VendorListVersion())
+}


### PR DESCRIPTION
Missing some bytes in the middle... added a regression test so it doesn't happen again. "3634" is `111000110010` in binary, which should be sufficiently "choppy" to prove that it's not missing more 4-bit chunks, or overlapping and matching by coincidence.