### PR TITLE
Adding a few missing consent string parsing functions

### DIFF
--- a/vendorconsent/bitfield_test.go
+++ b/vendorconsent/bitfield_test.go
@@ -15,15 +15,13 @@ func TestBitField(t *testing.T) {
 	// cookie version = 1
 	// created = Sun May 06 2018 12:31:13 GMT-0400 (EDT) (binary 001110001101010101111100101000101010)
 	// last updated = Mon May 07 2018 01:42:15 GMT-0400 (EDT) (binary 001110001101010111110000100000100110)
-	// cmpId = 3
-	// cmpVersion = 2
 	// consentScreen = 7
 	// consentLanguage = "en" (binary 000100001101)
 	consent, err := Parse(decode(t, "BONV8oqONXwgmADACHENAO7pqzAAppY"))
-	if err != nil {
-		t.Fatalf("Failed to parse valid consent string: %v", err)
-	}
+	assertNilError(t, err)
 	assertUInt8sEqual(t, 1, consent.Version())
+	assertUInt16sEqual(t, 3, consent.CmpID())
+	assertUInt16sEqual(t, 2, consent.CmpVersion())
 	assertUInt16sEqual(t, 14, consent.VendorListVersion())
 	assertUInt16sEqual(t, 10, consent.MaxVendorID())
 

--- a/vendorconsent/bitfield_test.go
+++ b/vendorconsent/bitfield_test.go
@@ -15,13 +15,13 @@ func TestBitField(t *testing.T) {
 	// cookie version = 1
 	// created = Sun May 06 2018 12:31:13 GMT-0400 (EDT) (binary 001110001101010101111100101000101010)
 	// last updated = Mon May 07 2018 01:42:15 GMT-0400 (EDT) (binary 001110001101010111110000100000100110)
-	// consentScreen = 7
-	// consentLanguage = "en" (binary 000100001101)
 	consent, err := Parse(decode(t, "BONV8oqONXwgmADACHENAO7pqzAAppY"))
 	assertNilError(t, err)
 	assertUInt8sEqual(t, 1, consent.Version())
 	assertUInt16sEqual(t, 3, consent.CmpID())
 	assertUInt16sEqual(t, 2, consent.CmpVersion())
+	assertUInt8sEqual(t, 7, consent.ConsentScreen())
+	assertStringsEqual(t, "EN", consent.ConsentLanguage())
 	assertUInt16sEqual(t, 14, consent.VendorListVersion())
 	assertUInt16sEqual(t, 10, consent.MaxVendorID())
 

--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -8,6 +8,18 @@ type VendorConsents interface {
 	// The version of the Consent string.
 	Version() uint8
 
+	// The ID of the CMP used to update the consent string.
+	CmpID() uint16
+
+	// The version of the CMP used to update the consent string
+	CmpVersion() uint16
+
+	// The number of the CMP screen where consent was given
+	ConsentScreen() uint8
+
+	// The two-letter ISO639-1 language code used by the CMP to ask for consent
+	ConsentLanguage() string
+
 	// The VendorListVersion which is needed to interpret this consent string.
 	//
 	// The IAB is hosting these on their webpage. For example, version 2 of the

--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -17,7 +17,7 @@ type VendorConsents interface {
 	// The number of the CMP screen where consent was given
 	ConsentScreen() uint8
 
-	// The two-letter ISO639-1 language code used by the CMP to ask for consent
+	// The two-letter ISO639-1 language code used by the CMP to ask for consent, in uppercase.
 	ConsentLanguage() string
 
 	// The VendorListVersion which is needed to interpret this consent string.

--- a/vendorconsent/consent_test.go
+++ b/vendorconsent/consent_test.go
@@ -86,6 +86,13 @@ func decode(t *testing.T, encodedString string) []byte {
 	return data
 }
 
+func assertStringsEqual(t *testing.T, expected string, actual string) {
+	t.Helper()
+	if actual != expected {
+		t.Errorf("Strings were not equal. Expected %s, actual %s", expected, actual)
+	}
+}
+
 func assertUInt8sEqual(t *testing.T, expected uint8, actual uint8) {
 	t.Helper()
 	if actual != expected {

--- a/vendorconsent/consent_test.go
+++ b/vendorconsent/consent_test.go
@@ -72,9 +72,7 @@ func TestInvalidConsentStrings(t *testing.T) {
 func assertInvalid(t *testing.T, urlEncodedString string, expectError string) {
 	t.Helper()
 	data, err := base64.RawURLEncoding.DecodeString(urlEncodedString)
-	if err != nil {
-		t.Fatalf("Failed to base64-decode string %s. Error: %v", urlEncodedString, err)
-	}
+	assertNilError(t, err)
 	if consent, err := Parse(data); err == nil {
 		t.Errorf("base64 URL-encoded string %s was considered valid, but shouldn't be. MaxVendorID: %d. len(data): %d", urlEncodedString, consent.MaxVendorID(), len(data))
 	} else if err.Error() != expectError {
@@ -84,9 +82,7 @@ func assertInvalid(t *testing.T, urlEncodedString string, expectError string) {
 
 func decode(t *testing.T, encodedString string) []byte {
 	data, err := base64.RawURLEncoding.DecodeString(encodedString)
-	if err != nil {
-		t.Fatalf("Failed to base64-decode string %s. Error: %v", encodedString, err)
-	}
+	assertNilError(t, err)
 	return data
 }
 

--- a/vendorconsent/metadata.go
+++ b/vendorconsent/metadata.go
@@ -34,7 +34,32 @@ func parseMetadata(data []byte) (consentMetadata, error) {
 type consentMetadata []byte
 
 func (c consentMetadata) Version() uint8 {
+	// Stored in bits 0-5
 	return uint8(c[0] >> 2)
+}
+
+func (c consentMetadata) CmpID() uint16 {
+	// Stored in bits 78-89... which is [000000xx xxxxxxxx xx000000] starting at the 10th byte
+	leftByte := ((c[9] & 0x03) << 2) | c[10]>>6
+	rightByte := (c[10] << 2) | c[11]>>6
+	return binary.BigEndian.Uint16([]byte{leftByte, rightByte})
+}
+
+func (c consentMetadata) CmpVersion() uint16 {
+	// Stored in bits 90-101.. which is [00xxxxxx xxxxxx00] starting at the 12th byte
+	leftByte := (c[11] >> 2) & 0x0f
+	rightByte := (c[11] << 6) | c[12]>>2
+	return binary.BigEndian.Uint16([]byte{leftByte, rightByte})
+}
+
+func (c consentMetadata) ConsentScreen() uint8 {
+	// Stored in bits 102-107.. which is [000000xx xxxx0000] starting at the 13th byte
+	return uint8(((c[12] & 0x03) << 4) | c[13]>>4)
+}
+
+func (c consentMetadata) ConsentLanguage() string {
+	// Stored in bits 108-119. Each letter is stored as 6 bits, with A=0 and Z=25
+	return ""
 }
 
 func (c consentMetadata) VendorListVersion() uint16 {

--- a/vendorconsent/metadata.go
+++ b/vendorconsent/metadata.go
@@ -58,8 +58,11 @@ func (c consentMetadata) ConsentScreen() uint8 {
 }
 
 func (c consentMetadata) ConsentLanguage() string {
-	// Stored in bits 108-119. Each letter is stored as 6 bits, with A=0 and Z=25
-	return ""
+	// Stored in bits 108-119... which is [0000xxxx xxxxxxxx] starting at the 14th byte.
+	// Each letter is stored as 6 bits, with A=0 and Z=25
+	leftChar := ((c[13] & 0x0f) << 2) | c[14]>>6
+	rightChar := c[14] & 0x3f
+	return string([]byte{leftChar + 65, rightChar + 65}) // Unicode A-Z is 65-90
 }
 
 func (c consentMetadata) VendorListVersion() uint16 {

--- a/vendorconsent/metadata_test.go
+++ b/vendorconsent/metadata_test.go
@@ -4,9 +4,30 @@ import "testing"
 
 func TestLargeVendorListVersion(t *testing.T) {
 	consent, err := Parse(decode(t, "BON96hFON96hFABABBAA4yAAAAAAEA"))
-	if err != nil {
-		t.Fatalf("Failed to parse valid consent string: %v", err)
-	}
-
+	assertNilError(t, err)
 	assertUInt16sEqual(t, 3634, consent.VendorListVersion())
+}
+
+func TestLargeCmpID(t *testing.T) {
+	consent, err := Parse(decode(t, "BOOG3gbOOG3gbFZABBAAABAAAAAAEA"))
+	assertNilError(t, err)
+	assertUInt16sEqual(t, 345, consent.CmpID())
+}
+
+func TestLargeCmpVersion(t *testing.T) {
+	consent, err := Parse(decode(t, "BOOG4uyOOG4uyABFZBAAABAAAAAAEA"))
+	assertNilError(t, err)
+	assertUInt16sEqual(t, 345, consent.CmpVersion())
+}
+
+func TestLargeConsentScreen(t *testing.T) {
+	consent, err := Parse(decode(t, "BOOG4uyOOG4uyABFZTAAABAAAAAAEA"))
+	assertNilError(t, err)
+	assertUInt8sEqual(t, 19, consent.ConsentScreen())
+}
+
+func assertNilError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 }

--- a/vendorconsent/metadata_test.go
+++ b/vendorconsent/metadata_test.go
@@ -26,6 +26,16 @@ func TestLargeConsentScreen(t *testing.T) {
 	assertUInt8sEqual(t, 19, consent.ConsentScreen())
 }
 
+func TestLanguageExtremes(t *testing.T) {
+	consent, err := Parse(decode(t, "BOOG9-6OOG9-6ABABBAZABAAAAAAEA"))
+	assertNilError(t, err)
+	assertStringsEqual(t, "AZ", consent.ConsentLanguage())
+
+	consent, err = Parse(decode(t, "BOOG9-6OOG9-6ABABBZAABAAAAAAEA"))
+	assertNilError(t, err)
+	assertStringsEqual(t, "ZA", consent.ConsentLanguage())
+}
+
 func assertNilError(t *testing.T, err error) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/vendorconsent/rangesection_test.go
+++ b/vendorconsent/rangesection_test.go
@@ -16,14 +16,13 @@ func TestRangeSectionConsent(t *testing.T) {
 	// created = Tue May 08 2018 12:31:13 GMT-0400 (EDT) (binary 001110001101011100100010100000101110)
 	// last updated = Tue May 08 2018 12:35:13 GMT-0400 (EDT) (binary 001110001101011100100011000110001010)
 	// cmpId = 3
-	// cmpVersion = 2
 	// consentScreen = 7
 	// consentLanguage = "en" (binary 000100001101)
 	consent, err := Parse(decode(t, "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw"))
-	if err != nil {
-		t.Fatalf("Failed to parse valid consent string: %v", err)
-	}
+	assertNilError(t, err)
 	assertUInt8sEqual(t, 1, consent.Version())
+	assertUInt16sEqual(t, 3, consent.CmpID())
+	assertUInt16sEqual(t, 2, consent.CmpVersion())
 	assertUInt16sEqual(t, 14, consent.VendorListVersion())
 	assertUInt16sEqual(t, 112, consent.MaxVendorID())
 
@@ -57,9 +56,7 @@ func TestParseUInt16(t *testing.T) {
 func doParseIntTest(t *testing.T, data []byte, offset int, expected int) {
 	t.Helper()
 	parsedVal, err := parseUInt16(data, uint(offset))
-	if err != nil {
-		t.Fatalf("Error parsing uint16: %v", err)
-	}
+	assertNilError(t, err)
 	if parsedVal != uint16(expected) {
 		t.Errorf("Failed to parse value. Got %d", parsedVal)
 	}

--- a/vendorconsent/rangesection_test.go
+++ b/vendorconsent/rangesection_test.go
@@ -15,14 +15,13 @@ func TestRangeSectionConsent(t *testing.T) {
 	// cookie version = 1
 	// created = Tue May 08 2018 12:31:13 GMT-0400 (EDT) (binary 001110001101011100100010100000101110)
 	// last updated = Tue May 08 2018 12:35:13 GMT-0400 (EDT) (binary 001110001101011100100011000110001010)
-	// cmpId = 3
-	// consentScreen = 7
-	// consentLanguage = "en" (binary 000100001101)
 	consent, err := Parse(decode(t, "BONciguONcjGKADACHENAOLS1rAHDAFAAEAASABQAMwAeACEAFw"))
 	assertNilError(t, err)
 	assertUInt8sEqual(t, 1, consent.Version())
 	assertUInt16sEqual(t, 3, consent.CmpID())
 	assertUInt16sEqual(t, 2, consent.CmpVersion())
+	assertUInt8sEqual(t, 7, consent.ConsentScreen())
+	assertStringsEqual(t, "EN", consent.ConsentLanguage())
 	assertUInt16sEqual(t, 14, consent.VendorListVersion())
 	assertUInt16sEqual(t, 112, consent.MaxVendorID())
 


### PR DESCRIPTION
This adds a few more functions to the consent string parser... the only two left now are `Created` and `LastUpdated()`.