### PR TITLE
Adding godocs + Travis tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-  <a href="https://goreportcard.com/report/github.com/prebid/go-gdpr"><img src="https://goreportcard.com/badge/github.com/prebid/go-gdpr" /></a>
- [![GoDoc](https://godoc.org/github.com/prebid/go-gdpr?status.svg)](https://godoc.org/github.com/prebid/go-gdpr)
+  [![Build
+Status](https://travis-ci.org/prebid/go-gdpr.svg?branch=master)](https://travis-ci.org/prebid/go-gdpr)
+  [![ReportCard](https://goreportcard.com/badge/github.com/prebid/go-gdpr)](https://goreportcard.com/report/github.com/prebid/go-gdpr)
+  [![GoDoc](https://godoc.org/github.com/prebid/go-gdpr?status.svg)](https://godoc.org/github.com/prebid/go-gdpr)
 
 # Go Support for GDPR
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
   <a href="https://goreportcard.com/report/github.com/prebid/go-gdpr"><img src="https://goreportcard.com/badge/github.com/prebid/go-gdpr" /></a>
+ [![GoDoc](https://godoc.org/github.com/prebid/go-gdpr?status.svg)](https://godoc.org/github.com/prebid/go-gdpr)
 
 # Go Support for GDPR
 


### PR DESCRIPTION
Seen these tags on other libraries... thought they looked pretty sweet. Figured I'd add 'em.

You can see how they render in the README on the branch-specific page: https://github.com/prebid/go-gdpr/tree/add-godocs-readme