### PR TITLE
Adding a ParseString function

### DIFF
--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -1,6 +1,7 @@
 package vendorconsent
 
 import (
+	"encoding/base64"
 	"time"
 
 	"github.com/prebid/go-gdpr/consentconstants"
@@ -58,6 +59,15 @@ type VendorConsents interface {
 	// It is the caller's responsibility to get the right Vendor List version for the semantics of the ID.
 	// For more information, see VendorListVersion().
 	VendorConsent(id uint16) bool
+}
+
+// ParseString parses a Raw (unpadded) base64 URL encoded string.
+func ParseString(consent string) (VendorConsents, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(consent)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(decoded)
 }
 
 // Parse the vendor consent data from the string. This string should *not* be encoded (by base64 or any other encoding).

--- a/vendorconsent/consent_test.go
+++ b/vendorconsent/consent_test.go
@@ -69,6 +69,19 @@ func TestInvalidConsentStrings(t *testing.T) {
 	assertInvalid(t, "BONciguONcjGKADACHENAOLS1rAAPABgAEAAIA", "bit 186 range entry excludes vendors [2, 1]. The start should be less than the end")
 }
 
+func TestParseInvalidString(t *testing.T) {
+	_, err := ParseString("/")
+	if err == nil {
+		t.Error("Strings with invalid base64 characters should be invalid.")
+	}
+}
+
+func TestParseValidString(t *testing.T) {
+	parsed, err := ParseString("BONV8oqONXwgmADACHENAO7pqzAAppY")
+	assertNilError(t, err)
+	assertUInt16sEqual(t, 14, parsed.VendorListVersion())
+}
+
 func assertInvalid(t *testing.T, urlEncodedString string, expectError string) {
 	t.Helper()
 	data, err := base64.RawURLEncoding.DecodeString(urlEncodedString)


### PR DESCRIPTION
The IAB examples generally use unpadded base64 URL encoded strings [in their examples](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#what-are-the-fields-of-the-global-vendor-consent-cookie-), so... probably safe to assume that most people will parse strings like this.

At the very least, I know that prebid-server and prebid.js assume it.