### PR TITLE
TCF 2.0 improvements: MaxVendorID 0, ParseVersion...

### DIFF
--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -2,6 +2,7 @@ package vendorconsent
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 
 	"github.com/prebid/go-gdpr/api"
@@ -16,11 +17,23 @@ func ParseString(consent string) (api.VendorConsents, error) {
 	if err != nil {
 		return nil, err
 	}
-	version := uint8(decoded[0] >> 2)
+	version, err := ParseVersion(decoded)
+	if err != nil {
+		return nil, err
+	}
 	if version == 2 {
 		return tcf2.Parse(decoded)
 	}
 	return tcf1.Parse(decoded)
+}
+
+// ParseVersion parses version from base64-decoded consent string
+func ParseVersion(decodedConsent []byte) (uint8, error) {
+	if len(decodedConsent) == 0 {
+		return 0, fmt.Errorf("decoded consent cannot be empty")
+	}
+	// read version from first 6 bits
+	return decodedConsent[0] >> 2, nil
 }
 
 // Backwards compatibility

--- a/vendorconsent/consent.go
+++ b/vendorconsent/consent.go
@@ -12,8 +12,9 @@ import (
 
 // ParseString parses a Raw (unpadded) base64 URL encoded string.
 func ParseString(consent string) (api.VendorConsents, error) {
-	pieces := strings.Split(consent, ".")
-	decoded, err := base64.RawURLEncoding.DecodeString(pieces[0])
+	// split TCF 2.0 segments
+	segments := strings.SplitN(consent, ".", 4) // specify max substrings to limit memory usage if there are a lot of occurrences of '.'
+	decoded, err := base64.RawURLEncoding.DecodeString(segments[0])
 	if err != nil {
 		return nil, err
 	}

--- a/vendorconsent/consent20_test.go
+++ b/vendorconsent/consent20_test.go
@@ -43,7 +43,7 @@ func TestInvalidConsentStrings20(t *testing.T) {
 	// These "bad requests" can be made by tweaking those values to get various errors.
 	// Bad metadata
 	assertInvalid20(t, "CONciguONcjGKADACHENAOCIAC0ta__AACiQAA", "vendor consent strings are at least 29 bytes long. This one was 28")
-	assertInvalid20(t, "AONciguONcjGKADACHENAOCIAC0ta__AACiQABgAAYA", "the consent string encoded a Version of 0, but this value must be greater than or equal to 1")
+	assertInvalid20(t, "BONciguONcjGKADACHENAOCIAC0ta__AACiQABgAAYA", "the consent string encoded a Version of 1, but this value must be greater than or equal to 2")
 	assertInvalid20(t, "CONciguONcjGKADACHENAACIAC0ta__AACiQABgAAYA", "the consent string encoded a VendorListVersion of 0, but this value must be greater than or equal to 1")
 
 	// Bad BitFields

--- a/vendorconsent/consent20_test.go
+++ b/vendorconsent/consent20_test.go
@@ -75,6 +75,21 @@ func TestParseValidString20MaxVendorID0(t *testing.T) {
 	assertUInt16sEqual(t, 15, parsed.VendorListVersion())
 }
 
+func TestParseEmptyString(t *testing.T) {
+	// checks there is no panic due to array out of bound
+	var err error
+
+	_, err = ParseString("")
+	if err == nil {
+		t.Errorf("expected an error from ParseString")
+	}
+
+	_, err = ParseVersion(make([]byte, 0))
+	if err == nil {
+		t.Errorf("expected an error from ParseVersion")
+	}
+}
+
 func assertInvalid20(t *testing.T, urlEncodedString string, expectError string) {
 	t.Helper()
 	data, err := base64.RawURLEncoding.DecodeString(urlEncodedString)

--- a/vendorconsent/consent20_test.go
+++ b/vendorconsent/consent20_test.go
@@ -12,7 +12,7 @@ func TestInvalidConsentStrings20(t *testing.T) {
 	// All strings here were encoded using https://cryptii.com/binary-to-base64 from binary to URL-encoded base64 string.
 	// Beware: this tool only makes sense if your binary strings use full bytes (multiples of 8 digits).
 	//
-	// For future tests, a "basline" of valid binary using a BitField, segmented by different vendor consent string semantics, is:
+	// For future tests, a "baseline" of valid binary using a BitField, segmented by different vendor consent string semantics, is:
 	//
 	// 000010                                 => Version
 	// 001110001101011100100010100000101110   => Created date
@@ -20,15 +20,15 @@ func TestInvalidConsentStrings20(t *testing.T) {
 	// 000000000011                           => CmpId
 	// 000000000010                           => CmpVersion
 	// 000111                                 => ConsentScreen
-	// 000100001101                           => ConsentLangugae
+	// 000100001101                           => ConsentLanguage
 	// 000000001110                           => VendorListVersion
 	// 000010								  => TcfPolicyVersion
 	// 0 									  => IsServiceSpecific
 	// 0									  => UseNonStandardStacks
-	// 100000000000							  => SpecialFeatureOptins
+	// 100000000000							  => SpecialFeatureOptIns
 	// 001011010010110101101011               => PurposesConsent
 	// 111111111100000000000000				  => PurposesLITransparency
-	// 0									  => PurposeOneTreatement
+	// 0									  => PurposeOneTreatment
 	// 010100010010							  => PublisherCC (US if I did tge math right)
 	// 0000000000000011                       => MaxVendorID <= Vendor Consent
 	// 0                                      => EncodingType
@@ -44,7 +44,6 @@ func TestInvalidConsentStrings20(t *testing.T) {
 	// Bad metadata
 	assertInvalid20(t, "CONciguONcjGKADACHENAOCIAC0ta__AACiQAA", "vendor consent strings are at least 29 bytes long. This one was 28")
 	assertInvalid20(t, "AONciguONcjGKADACHENAOCIAC0ta__AACiQABgAAYA", "the consent string encoded a Version of 0, but this value must be greater than or equal to 1")
-	assertInvalid20(t, "CONciguONcjGKADACHENAOCIAC0ta__AACiQAAAAAMA", "the consent string encoded a MaxVendorID of 0, but this value must be greater than or equal to 1")
 	assertInvalid20(t, "CONciguONcjGKADACHENAACIAC0ta__AACiQABgAAYA", "the consent string encoded a VendorListVersion of 0, but this value must be greater than or equal to 1")
 
 	// Bad BitFields
@@ -66,6 +65,14 @@ func TestParseValidString20(t *testing.T) {
 	parsed, err := ParseString("CONciguONcjGKADACHENAOCIAC0ta__AACiQABgAAYA")
 	assertNilError(t, err)
 	assertUInt16sEqual(t, 14, parsed.VendorListVersion())
+}
+
+func TestParseValidString20MaxVendorID0(t *testing.T) {
+	parsed, err := ParseString("COwJz-rOwJz-rMLAEAFRAPCgAAAAAAAAAAqIAAAAAAAA")
+	assertNilError(t, err)
+	// if vendor consent is empty, max vendor ID may be 0. See https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/121
+	assertUInt16sEqual(t, 0, parsed.MaxVendorID())
+	assertUInt16sEqual(t, 15, parsed.VendorListVersion())
 }
 
 func assertInvalid20(t *testing.T, urlEncodedString string, expectError string) {

--- a/vendorconsent/tcf2/metadata.go
+++ b/vendorconsent/tcf2/metadata.go
@@ -16,8 +16,8 @@ func parseMetadata(data []byte) (consentMetadata, error) {
 		return nil, fmt.Errorf("vendor consent strings are at least 29 bytes long. This one was %d", len(data))
 	}
 	metadata := consentMetadata(data)
-	if metadata.Version() < 1 {
-		return nil, fmt.Errorf("the consent string encoded a Version of %d, but this value must be greater than or equal to 1", metadata.Version())
+	if metadata.Version() < 2 {
+		return nil, fmt.Errorf("the consent string encoded a Version of %d, but this value must be greater than or equal to 2", metadata.Version())
 	}
 	if metadata.VendorListVersion() == 0 {
 		return nil, errors.New("the consent string encoded a VendorListVersion of 0, but this value must be greater than or equal to 1")

--- a/vendorconsent/tcf2/metadata.go
+++ b/vendorconsent/tcf2/metadata.go
@@ -9,16 +9,13 @@ import (
 	"github.com/prebid/go-gdpr/consentconstants"
 )
 
-// Parse the metadata from the consent string.
+// parseMetadata parses the metadata from the consent string.
 // This returns an error if the input is too short to answer questions about that data.
 func parseMetadata(data []byte) (consentMetadata, error) {
 	if len(data) < 29 {
 		return nil, fmt.Errorf("vendor consent strings are at least 29 bytes long. This one was %d", len(data))
 	}
 	metadata := consentMetadata(data)
-	if metadata.MaxVendorID() < 1 {
-		return nil, fmt.Errorf("the consent string encoded a MaxVendorID of %d, but this value must be greater than or equal to 1", metadata.MaxVendorID())
-	}
 	if metadata.Version() < 1 {
 		return nil, fmt.Errorf("the consent string encoded a Version of %d, but this value must be greater than or equal to 1", metadata.Version())
 	}
@@ -26,10 +23,10 @@ func parseMetadata(data []byte) (consentMetadata, error) {
 		return nil, errors.New("the consent string encoded a VendorListVersion of 0, but this value must be greater than or equal to 1")
 
 	}
-	return consentMetadata(data), nil
+	return data, nil
 }
 
-// consemtMetadata implements the parts of the VendorConsents interface which are common
+// consentMetadata implements the parts of the VendorConsents interface which are common
 // to BitFields and RangeSections. This relies on Parse to have done some validation already,
 // to make sure that functions on it don't overflow the bounds of the byte array.
 type consentMetadata []byte
@@ -110,8 +107,8 @@ func (c consentMetadata) VendorListVersion() uint16 {
 
 func (c consentMetadata) MaxVendorID() uint16 {
 	// The max vendor ID is stored in bits 213 - 228 [00000xxx xxxxxxxx xxxxx000]
-	leftByte := byte((c[26]&0x07)<<5 + (c[27]&0xf8)>>3)
-	rightByte := byte((c[27]&0x07)<<5 + (c[28]&0xf8)>>3)
+	leftByte := ((c[26] & 0x07) << 5) | ((c[27] & 0xf8) >> 3)
+	rightByte := ((c[27] & 0x07) << 5) | ((c[28] & 0xf8) >> 3)
 	return binary.BigEndian.Uint16([]byte{leftByte, rightByte})
 }
 


### PR DESCRIPTION
Followup to PR https://github.com/prebid/go-gdpr/pull/13
* add `ParseVersion()` function to fix panic when decoded string was empty and allow client code of this lib to parse version easily, e.g. to build TCF1 vs TCF2 logic 
* accept use of MaxVendorID of 0 to denote no vendor consent, this is part of the TCF 2.0 spec, see this [comment](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/121#issuecomment-602853401)
* require consent string version 2+ for TCF 2.0