### PR TITLE
Fix issue with consent without pub restrictions issue: #20

### DIFF
--- a/bitutils/bitutils.go
+++ b/bitutils/bitutils.go
@@ -48,15 +48,16 @@ func ParseByte8(data []byte, bitStartIndex uint) (byte, error) {
 
 // ParseUInt12 parses 12 bits of data fromt the data array, starting at the given index
 func ParseUInt12(data []byte, bitStartIndex uint) (uint16, error) {
-	startByte := bitStartIndex / 8
-	bitStartOffset := bitStartIndex % 8
-	if bitStartOffset < 4 {
-		if uint(len(data)) < (startByte + 2) {
-			return 0, fmt.Errorf("ParseUInt12 expected a 12-bit int to start at bit %d, but the consent string was only %d bytes long", bitStartIndex, len(data))
-		}
+	end := bitStartIndex + 12
+	endByte := end / 8
+	endOffset := end % 8
+
+	if endOffset > 0 {
+		endByte++
 	}
-	if uint(len(data)) < (startByte+3) && bitStartOffset > 3 {
-		return 0, fmt.Errorf("ParseUInt12 expected a 12-bit int to start at bit %d, but the consent string was only %d bytes long", bitStartIndex, len(data))
+	if uint(len(data)) < endByte {
+		return 0, fmt.Errorf("ParseUInt12 expected a 12-bit int to start at bit %d, but the consent string was only %d bytes long",
+			bitStartIndex, len(data))
 	}
 
 	leftByte, err := ParseByte4(data, bitStartIndex)

--- a/bitutils/bitutils_test.go
+++ b/bitutils/bitutils_test.go
@@ -71,6 +71,7 @@ var test12Bits = []testDefinition{
 	{testdata, 1, 148},   // Odd offset that fits 2 bytes
 	{testdata, 22, 3780}, // Another even unaligned offset that overflows to 3rd byte
 	{testdata, 4, 1186},  // Offset that aligns to a nibble (these can never overflow)
+	{testdata, 36, 0x2b}, // Corner Case
 }
 
 func TestParseUInt12(t *testing.T) {
@@ -79,6 +80,9 @@ func TestParseUInt12(t *testing.T) {
 
 	i, err = ParseUInt12(testdata, 40)
 	assertStringsEqual(t, "ParseUInt12 expected a 12-bit int to start at bit 40, but the consent string was only 6 bytes long", err.Error())
+
+	i, err = ParseUInt12(testdata, 37)
+	assertStringsEqual(t, "ParseUInt12 expected a 12-bit int to start at bit 37, but the consent string was only 6 bytes long", err.Error())
 
 	for _, test := range test12Bits {
 		i, err = ParseUInt12(test.data, test.offset)

--- a/vendorconsent/tcf2/pubrestrict_test.go
+++ b/vendorconsent/tcf2/pubrestrict_test.go
@@ -49,3 +49,8 @@ func TestPubRestrictions2(t *testing.T) {
 	// Verifying that this special case doesn't bleed over to other vendors.
 	assertBoolsEqual(t, false, consent.CheckPubRestriction(2, 1, 42))
 }
+
+func TestPubRestrictions3(t *testing.T) {
+	_, err := Parse(decode(t, "COzSDo9OzSDo9B9AAAENAiCAALAAAAAAAAAACOQAQCOAAAAA"))
+	assertNilError(t, err)
+}


### PR DESCRIPTION
For some reason, there are a corner case when we want to parse the last 12 bits, the original code does not work.

I change the logic a little bit to check what is the last byte and then check it is present

enjoy