### PR TITLE
Make `rangeConsent` a struct type

### DIFF
--- a/vendorconsent/tcf2/pubrestrict.go
+++ b/vendorconsent/tcf2/pubrestrict.go
@@ -31,12 +31,11 @@ func parsePubRestriction(metadata ConsentMetadata, startbit uint) (*pubRestricti
 		}
 		currentOffset = currentOffset + 12
 		vendors := make([]rangeConsent, numEntries)
-		for i := uint16(0); i < numEntries; i++ {
-			thisConsent, bitsConsumed, err := parseRangeConsent(data, currentOffset, assumedMaxVendorID)
+		for i := range vendors {
+			bitsConsumed, err := parseRangeConsent(&vendors[i], data, currentOffset, assumedMaxVendorID)
 			if err != nil {
 				return nil, 0, err
 			}
-			vendors[i] = thisConsent
 			currentOffset = currentOffset + bitsConsumed
 		}
 		restrictions[restrictData] = pubRestriction{


### PR DESCRIPTION
The virtual call and additional indirections outweigh the cost of
storing and comparing a uint16. This reduces allocation count and memory
usage enormously for v2 consents with lots of ranges.

    benchmark                                                                         old ns/op     new ns/op     delta
    BenchmarkParse/all_testcases-8                                                    3157          2536          -19.67%
    BenchmarkParse/case_short_consent_v2_ok-8                                         462           424           -8.22%
    BenchmarkParse/case_long_consent_v2_ok-8                                          462           428           -7.50%
    BenchmarkParse/case_really_long_consent_v2_ok-8                                   19662         12845         -34.67%

    benchmark                                                                         old allocs     new allocs     delta
    BenchmarkParse/all_testcases-8                                                    31             5              -83.87%
    BenchmarkParse/case_short_consent_v2_ok-8                                         8              7              -12.50%
    BenchmarkParse/case_long_consent_v2_ok-8                                          8              7              -12.50%
    BenchmarkParse/case_really_long_consent_v2_ok-8                                   313            22             -92.97%

    benchmark                                                                         old bytes     new bytes     delta
    BenchmarkParse/all_testcases-8                                                    7195          6586          -8.46%
    BenchmarkParse/case_short_consent_v2_ok-8                                         330           284           -13.94%
    BenchmarkParse/case_long_consent_v2_ok-8                                          330           284           -13.94%
    BenchmarkParse/case_really_long_consent_v2_ok-8                                   11988         5388          -55.06%

Remove the original `consentData` from `rangeSection` as it’s unused and
relatively large.