### PR TITLE
Retract v1.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,6 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/stretchr/testify v1.7.0
 )
+
+// Version v0.9.0 was accidently tagged as v1.9.0.
+retract v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/stretchr/testify v1.7.0
 )
 
-// Version v0.9.0 was accidently tagged as v1.9.0.
+// Version v0.9.0 was accidentally tagged as v1.9.0.
 retract v1.9.0


### PR DESCRIPTION
RE: https://github.com/prebid/go-gdpr/issues/32

Version v0.9.0 was accidentally tagged as v1.9.0. The tag was removed, but Go Proxy picked it up. Retracting version v1.9.0 as the official way to mark this tag as having a problem.