### PR TITLE
Add special feature support to vendor list parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 vendor/
+
+.idea/
+.vscode/

--- a/api/vendorlist.go
+++ b/api/vendorlist.go
@@ -1,6 +1,7 @@
 package api
 
 import "github.com/prebid/go-gdpr/consentconstants"
+import tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 
 // VendorList is an interface used to fetch information about an IAB Global Vendor list.
 // For the latest version, see: https://vendorlist.consensu.org/vendorlist.json
@@ -34,4 +35,6 @@ type Vendor interface {
 	LegitimateInterestStrict(purposeID consentconstants.Purpose) (hasLegitimateInterest bool)
 	// SpecialPurpose returns true if this vendor claims a need for the given special purpose
 	SpecialPurpose(purposeID consentconstants.Purpose) (hasSpecialPurpose bool)
+	// SpecialFeature returns true if this vendor claims a need for the given special feature
+	SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) (hasSpecialFeature bool)
 }

--- a/api/vendorlist.go
+++ b/api/vendorlist.go
@@ -1,7 +1,6 @@
 package api
 
 import "github.com/prebid/go-gdpr/consentconstants"
-import tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 
 // VendorList is an interface used to fetch information about an IAB Global Vendor list.
 // For the latest version, see: https://vendorlist.consensu.org/vendorlist.json
@@ -36,5 +35,5 @@ type Vendor interface {
 	// SpecialPurpose returns true if this vendor claims a need for the given special purpose
 	SpecialPurpose(purposeID consentconstants.Purpose) (hasSpecialPurpose bool)
 	// SpecialFeature returns true if this vendor claims a need for the given special feature
-	SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) (hasSpecialFeature bool)
+	SpecialFeature(featureID consentconstants.SpecialFeature) (hasSpecialFeature bool)
 }

--- a/consentconstants/features.go
+++ b/consentconstants/features.go
@@ -1,0 +1,6 @@
+package consentconstants
+
+// SpecialFeature is one of the IAB GDPR special features. These appear in:
+//   1. `root.specialFeatures[i]` of the vendor list: https://vendorlist.consensu.org/vendorlist.json
+//   2. SpecialFeatureOptIns of the Consent string: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-
+type SpecialFeature uint8

--- a/consentconstants/tcf2/features.go
+++ b/consentconstants/tcf2/features.go
@@ -1,15 +1,12 @@
 package consentconstants
 
-// SpecialFeature is one of the IAB GDPR special features. These appear in:
-//   1. `root.specialFeatures[i]` of the vendor list: https://vendorlist.consensu.org/vendorlist.json
-//   2. SpecialFeatureOptIns of the Consent string: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-
-type SpecialFeature uint8
+import base "github.com/prebid/go-gdpr/consentconstants"
 
 // TCF 2.0 Special Features:
 const (
 	// Use precise geolocation data to select and deliver an ad in the moment, without storing it.
-	Geolocation SpecialFeature = 1
+	Geolocation base.SpecialFeature = 1
 
 	// Identify a device by actively scanning device characteristics in order to select an ad in the moment.
-	DeviceScan SpecialFeature = 2
+	DeviceScan base.SpecialFeature = 2
 )

--- a/consentconstants/tcf2/features.go
+++ b/consentconstants/tcf2/features.go
@@ -1,0 +1,15 @@
+package consentconstants
+
+// SpecialFeature is one of the IAB GDPR special features. These appear in:
+//   1. `root.specialFeatures[i]` of the vendor list: https://vendorlist.consensu.org/vendorlist.json
+//   2. SpecialFeatureOptIns of the Consent string: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-
+type SpecialFeature uint8
+
+// TCF 2.0 Special Features:
+const (
+	// Use precise geolocation data to select and deliver an ad in the moment, without storing it.
+	Geolocation SpecialFeature = 1
+
+	// Identify a device by actively scanning device characteristics in order to select an ad in the moment.
+	DeviceScan SpecialFeature = 2
+)

--- a/vendorlist/eager-parsing.go
+++ b/vendorlist/eager-parsing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
+	tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 )
 
 // ParseEagerly interprets and validates the Vendor List data up front, before returning it.
@@ -106,8 +107,13 @@ func (l parsedVendor) LegitimateInterestStrict(purposeID consentconstants.Purpos
 	return
 }
 
-// V1 vedndor list does not support special purposes.
+// V1 vendor list does not support special purposes.
 func (l parsedVendor) SpecialPurpose(purposeID consentconstants.Purpose) bool {
+	return false
+}
+
+// V1 vendor list does not support special features.
+func (l parsedVendor) SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) bool {
 	return false
 }
 

--- a/vendorlist/eager-parsing.go
+++ b/vendorlist/eager-parsing.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
-	tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 )
 
 // ParseEagerly interprets and validates the Vendor List data up front, before returning it.
@@ -113,7 +112,7 @@ func (l parsedVendor) SpecialPurpose(purposeID consentconstants.Purpose) bool {
 }
 
 // V1 vendor list does not support special features.
-func (l parsedVendor) SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) bool {
+func (l parsedVendor) SpecialFeature(featureID consentconstants.SpecialFeature) bool {
 	return false
 }
 

--- a/vendorlist/lazy-parsing.go
+++ b/vendorlist/lazy-parsing.go
@@ -6,7 +6,6 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
-	tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 )
 
 // ParseLazily returns a view of the data which re-calculates things on each function call.
@@ -70,7 +69,7 @@ func (l lazyVendor) SpecialPurpose(purposeID consentconstants.Purpose) bool {
 }
 
 // V1 vendor list does not support special features.
-func (l lazyVendor) SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) bool {
+func (l lazyVendor) SpecialFeature(featureID consentconstants.SpecialFeature) bool {
 	return false
 }
 

--- a/vendorlist/lazy-parsing.go
+++ b/vendorlist/lazy-parsing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
+	tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 )
 
 // ParseLazily returns a view of the data which re-calculates things on each function call.
@@ -63,8 +64,13 @@ func (l lazyVendor) LegitimateInterestStrict(purposeID consentconstants.Purpose)
 	return idExists(l, int(purposeID), "legIntPurposeIds")
 }
 
-// V1 vedndor list does not support special purposes.
+// V1 vendor list does not support special purposes.
 func (l lazyVendor) SpecialPurpose(purposeID consentconstants.Purpose) bool {
+	return false
+}
+
+// V1 vendor list does not support special features.
+func (l lazyVendor) SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) bool {
 	return false
 }
 

--- a/vendorlist2/eager-parsing.go
+++ b/vendorlist2/eager-parsing.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
-	tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 )
 
 // ParseEagerly interprets and validates the Vendor List data up front, before returning it.
@@ -60,11 +59,11 @@ func mapifyPurpose(input []uint8) map[consentconstants.Purpose]struct{} {
 	return m
 }
 
-func mapifySpecialFeature(input []uint8) map[tcf2ConsentConstants.SpecialFeature]struct{} {
-	m := make(map[tcf2ConsentConstants.SpecialFeature]struct{}, len(input))
+func mapifySpecialFeature(input []uint8) map[consentconstants.SpecialFeature]struct{} {
+	m := make(map[consentconstants.SpecialFeature]struct{}, len(input))
 	var s struct{}
 	for _, value := range input {
-		m[tcf2ConsentConstants.SpecialFeature(value)] = s
+		m[consentconstants.SpecialFeature(value)] = s
 	}
 	return m
 }
@@ -91,7 +90,7 @@ type parsedVendor struct {
 	legitimateInterests map[consentconstants.Purpose]struct{}
 	flexiblePurposes    map[consentconstants.Purpose]struct{}
 	specialPurposes     map[consentconstants.Purpose]struct{}
-	specialFeatures     map[tcf2ConsentConstants.SpecialFeature]struct{}
+	specialFeatures     map[consentconstants.SpecialFeature]struct{}
 }
 
 func (l parsedVendor) Purpose(purposeID consentconstants.Purpose) (hasPurpose bool) {
@@ -133,7 +132,7 @@ func (l parsedVendor) SpecialPurpose(purposeID consentconstants.Purpose) (hasSpe
 }
 
 // SpecialFeature returns true if this vendor claims a need for the given special feature
-func (l parsedVendor) SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) (hasSpecialFeature bool) {
+func (l parsedVendor) SpecialFeature(featureID consentconstants.SpecialFeature) (hasSpecialFeature bool) {
 	_, hasSpecialFeature = l.specialFeatures[featureID]
 	return
 }

--- a/vendorlist2/lazy-parsing.go
+++ b/vendorlist2/lazy-parsing.go
@@ -6,7 +6,6 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
-	tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 )
 
 // ParseLazily returns a view of the data which re-calculates things on each function call.
@@ -72,7 +71,7 @@ func (l lazyVendor) SpecialPurpose(purposeID consentconstants.Purpose) (hasSpeci
 }
 
 // SpecialFeature returns true if this vendor claims a need for the given special feature
-func (l lazyVendor) SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) (hasSpecialFeature bool) {
+func (l lazyVendor) SpecialFeature(featureID consentconstants.SpecialFeature) (hasSpecialFeature bool) {
 	return idExists(l, int(featureID), "specialFeatures")
 }
 

--- a/vendorlist2/lazy-parsing.go
+++ b/vendorlist2/lazy-parsing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/prebid/go-gdpr/api"
 	"github.com/prebid/go-gdpr/consentconstants"
+	tcf2ConsentConstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
 )
 
 // ParseLazily returns a view of the data which re-calculates things on each function call.
@@ -68,6 +69,11 @@ func (l lazyVendor) LegitimateInterestStrict(purposeID consentconstants.Purpose)
 // SpecialPurpose returns true if this vendor claims a need for the given special purpose
 func (l lazyVendor) SpecialPurpose(purposeID consentconstants.Purpose) (hasSpecialPurpose bool) {
 	return idExists(l, int(purposeID), "specialPurposes")
+}
+
+// SpecialFeature returns true if this vendor claims a need for the given special feature
+func (l lazyVendor) SpecialFeature(featureID tcf2ConsentConstants.SpecialFeature) (hasSpecialFeature bool) {
+	return idExists(l, int(featureID), "specialFeatures")
 }
 
 // Returns false unless "id" exists in an array located at "data.key".

--- a/vendorlist2/shared_test.go
+++ b/vendorlist2/shared_test.go
@@ -73,6 +73,10 @@ func vendorTester(parser func(data []byte) api.VendorList) func(*testing.T) {
 		assertBoolsEqual(t, false, v.LegitimateInterest(3))
 		assertBoolsEqual(t, false, v.LegitimateInterestStrict(3))
 
+		assertBoolsEqual(t, false, v.SpecialPurpose(1))
+		assertBoolsEqual(t, false, v.SpecialPurpose(2))
+		assertBoolsEqual(t, false, v.SpecialPurpose(3)) // Does not exist yet
+		
 		assertBoolsEqual(t, false, v.SpecialFeature(1))
 		assertBoolsEqual(t, false, v.SpecialFeature(2))
 		assertBoolsEqual(t, false, v.SpecialFeature(3)) // Does not exist yet

--- a/vendorlist2/shared_test.go
+++ b/vendorlist2/shared_test.go
@@ -48,6 +48,10 @@ func vendorTester(parser func(data []byte) api.VendorList) func(*testing.T) {
 		assertBoolsEqual(t, true, v.SpecialPurpose(2))
 		assertBoolsEqual(t, false, v.SpecialPurpose(3)) // Does not exist yet
 
+		assertBoolsEqual(t, true, v.SpecialFeature(1))
+		assertBoolsEqual(t, true, v.SpecialFeature(2))
+		assertBoolsEqual(t, false, v.SpecialFeature(3)) // Does not exist yet
+
 		v = list.Vendor(80)
 		assertBoolsEqual(t, true, v.Purpose(1))
 		assertBoolsEqual(t, true, v.PurposeStrict(1))
@@ -69,9 +73,9 @@ func vendorTester(parser func(data []byte) api.VendorList) func(*testing.T) {
 		assertBoolsEqual(t, false, v.LegitimateInterest(3))
 		assertBoolsEqual(t, false, v.LegitimateInterestStrict(3))
 
-		assertBoolsEqual(t, false, v.SpecialPurpose(1))
-		assertBoolsEqual(t, false, v.SpecialPurpose(2))
-		assertBoolsEqual(t, false, v.SpecialPurpose(3)) // Does not exist yet
+		assertBoolsEqual(t, false, v.SpecialFeature(1))
+		assertBoolsEqual(t, false, v.SpecialFeature(2))
+		assertBoolsEqual(t, false, v.SpecialFeature(3)) // Does not exist yet
 	}
 
 }
@@ -91,7 +95,7 @@ const testData = `
 			"flexiblePurposes": [2, 9],
 			"specialPurposes": [1, 2],
 			"features": [1, 2],
-			"specialFeatures": [],
+			"specialFeatures": [1, 2],
 			"policyUrl": "https://www.emerse.com/privacy-policy/"
 		},
 		"80": {


### PR DESCRIPTION
This library supports TCF1 and TCF2. Special features are introduced in the TCF2 framework and are not a part of the TCF1 framework.

The TCF2 GVL contains a list of special features and, for every vendor, the list of special features they use across purposes: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list

There are only two special features defined in the TCF2 framework:
https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/#___D_Special_Features__

Special features are opt-in. See `SpecialFeatureOptIns` here: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-core-string

This library has eager and lazy parsers for both TCF1 and TCF2. The parsers process the GVL as JSON mapping the data to structs and then each parser has a method on it making it easy to access a given special feature to see if the vendor opts in.