### PR TITLE
Fix: out of bounds crashes with invalid consent strings

### DIFF
--- a/vendorconsent/tcf2/bitfield.go
+++ b/vendorconsent/tcf2/bitfield.go
@@ -7,7 +7,8 @@ import (
 func parseBitField(metadata ConsentMetadata, vendorBitsRequired uint16, startbit uint) (*consentBitField, uint, error) {
 	data := metadata.data
 
-	bytesRequired := (uint(vendorBitsRequired) + startbit) / 8
+	// add 7 to force rounding to next integer value
+	bytesRequired := (uint(vendorBitsRequired) + startbit + 7) / 8
 	if uint(len(data)) < bytesRequired {
 		return nil, 0, fmt.Errorf("a BitField for %d vendors requires a consent string of %d bytes. This consent string had %d", vendorBitsRequired, bytesRequired, len(data))
 	}

--- a/vendorconsent/tcf2/bitfield_test.go
+++ b/vendorconsent/tcf2/bitfield_test.go
@@ -31,3 +31,12 @@ func TestBitField(t *testing.T) {
 		assertBoolsEqual(t, ok, consent.VendorConsent(i))
 	}
 }
+
+func TestParseBitFieldRounding(t *testing.T) {
+	// crafted metadata to have 232 bits of data
+	data := make([]byte, 29)
+	metadata := ConsentMetadata{data: data}
+	// having 3 vendors with 230 bits of header should require 30 bytes of data (233 bits rounded to upper byte)
+	_, _, err := parseBitField(metadata, 3, 230)
+	assertError(t, err)
+}

--- a/vendorconsent/tcf2/consent_test.go
+++ b/vendorconsent/tcf2/consent_test.go
@@ -1,0 +1,17 @@
+package vendorconsent
+
+import (
+	"testing"
+)
+
+func TestParseLegitIntSetWithBitField(t *testing.T) {
+	// this test uses a crafted consent uses bit field, declares 10 vendors and legitimate interest without required content
+	_, err := Parse(decode(t, "COvcSpYOvcSpYC9AAAENAPCAAAAAAAAAAAAAAFAAAAA"))
+	assertError(t, err)
+}
+
+func TestParseLegitIntSetWithRangeSection(t *testing.T) {
+	// this test uses a crafted consent uses range section, declares 10 vendors, 6 exceptions and legitimate interest without required content
+	_, err := Parse(decode(t, "COvcSpYOvcSpYC9AAAENAPCAAAAAAAAAAAAAAFQBgAAgABAACAAEAAQAAgAA"))
+	assertError(t, err)
+}

--- a/vendorconsent/tcf2/test_utils.go
+++ b/vendorconsent/tcf2/test_utils.go
@@ -33,6 +33,12 @@ func assertNilError(t *testing.T, err error) {
 	}
 }
 
+func assertError(t *testing.T, err error) {
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+}
+
 func assertStringsEqual(t *testing.T, expected string, actual string) {
 	t.Helper()
 	if actual != expected {


### PR DESCRIPTION
This PR contains 2 fixes:
* The `bytesRequired` amount in `parseBitField` was incorrectly rounded down which could lead to out of bound issue
* There was no test before reading at `legitIntStart+16` which can create out of bound issues with invalid consent strings

It also adds 3 tests:
* Validate the correct processing of `bytesRequired` in `parseBitField`
* Proof of concept that allows the previously unfixed code to crash:
    * with a crafted consent string going through the initial `parseRangeSection`
    * with a crafted consent string going through the initial `parseBitField`