### PR TITLE
fix unit test and perform small refactor on other errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+---
+name: Go
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.13.x', '1.23.x', '1.24.x']
+    name: Go ${{ matrix.go }} job
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Test
+        run: make test
+
+      - name: Coverage
+        run: make coverage

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.13.x', '1.23.x', '1.24.x']
+        go: ['1.16.x', '1.23.x', '1.24.x']
     name: Go ${{ matrix.go }} job
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: info fmt goimports gofumpt lint go_fix go_vet golangci test coverage clean
+
+info:
+	go version
+
+fmt: goimports gofumpt
+	$(info === format done)
+
+goimports:
+	goimports -e -l -w -local github.com/prebid/go-gdpr .
+
+gofumpt:
+	gofumpt -l -w -extra .
+
+lint: go.sum go_fix go_vet golangci
+	$(info === lint done)
+
+go.mod:
+	go mod tidy
+	go mod verify
+
+go.sum: go.mod
+
+go_fix:
+	go fix ./...
+
+go_vet:
+	go vet -all ./...
+
+golangci:
+	golangci-lint run ./...
+
+test:
+	go test -v ./...
+
+coverage:
+	export GOEXPERIMENT="nocoverageredesign"
+	go test -v -race -cover -covermode=atomic -coverprofile coverage.out ./...
+
+clean:
+	rm -f $(BINARY)
+	rm -f coverage.*
+	rm -f .test_report.xml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Status](https://travis-ci.org/prebid/go-gdpr.svg?branch=master)](https://travis-ci.org/prebid/go-gdpr)
   [![ReportCard](https://goreportcard.com/badge/github.com/prebid/go-gdpr)](https://goreportcard.com/report/github.com/prebid/go-gdpr)
   [![GoDoc](https://godoc.org/github.com/prebid/go-gdpr?status.svg)](https://godoc.org/github.com/prebid/go-gdpr)
+  [![Go](https://github.com/prebid/go-gdpr/actions/workflows/go.yml/badge.svg)](https://github.com/prebid/go-gdpr/actions/workflows/go.yml)
+
 
 # Go Support for GDPR
 

--- a/bitutils/bitutils.go
+++ b/bitutils/bitutils.go
@@ -37,7 +37,7 @@ func ParseByte8(data []byte, bitStartIndex uint) (byte, error) {
 		return data[startByte], nil
 	}
 	if uint(len(data)) < (startByte + 2) {
-		return 0, fmt.Errorf("ParseByte8 expected 8 bitst to start at bit %d, but the consent string was only %d bytes long", bitStartIndex, len(data))
+		return 0, fmt.Errorf("ParseByte8 expected 8 bits to start at bit %d, but the consent string was only %d bytes long", bitStartIndex, len(data))
 	}
 
 	leftBits := (data[startByte] & (0xff >> bitStartOffset)) << bitStartOffset

--- a/bitutils/bitutils.go
+++ b/bitutils/bitutils.go
@@ -62,11 +62,11 @@ func ParseUInt12(data []byte, bitStartIndex uint) (uint16, error) {
 
 	leftByte, err := ParseByte4(data, bitStartIndex)
 	if err != nil {
-		return 0, fmt.Errorf("ParseUInt12 error on left byte: %s", err)
+		return 0, fmt.Errorf("ParseUInt12 error on left byte: %w", err)
 	}
 	rightByte, err := ParseByte8(data, bitStartIndex+4)
 	if err != nil {
-		return 0, fmt.Errorf("ParseUInt12 error on right byte: %s", err)
+		return 0, fmt.Errorf("ParseUInt12 error on right byte: %w", err)
 	}
 	return binary.BigEndian.Uint16([]byte{leftByte, rightByte}), nil
 }
@@ -87,11 +87,11 @@ func ParseUInt16(data []byte, bitStartIndex uint) (uint16, error) {
 
 	leftByte, err := ParseByte8(data, bitStartIndex)
 	if err != nil {
-		return 0, fmt.Errorf("ParseUInt16 error on left byte: %s", err)
+		return 0, fmt.Errorf("ParseUInt16 error on left byte: %w", err)
 	}
 	rightByte, err := ParseByte8(data, bitStartIndex+8)
 	if err != nil {
-		return 0, fmt.Errorf("ParseUInt16 error on right byte: %s", err)
+		return 0, fmt.Errorf("ParseUInt16 error on right byte: %w", err)
 	}
 	return binary.BigEndian.Uint16([]byte{leftByte, rightByte}), nil
 }

--- a/bitutils/bitutils_test.go
+++ b/bitutils/bitutils_test.go
@@ -52,10 +52,10 @@ var test8Bits = []testDefinition{
 
 func TestParseByte8(t *testing.T) {
 	b, err := ParseByte8([]byte{0x44, 0x76}, 11)
-	assertStringsEqual(t, "ParseByte8 expected 8 bitst to start at bit 11, but the consent string was only 2 bytes long", err.Error())
+	assertStringsEqual(t, "ParseByte8 expected 8 bits to start at bit 11, but the consent string was only 2 bytes long", err.Error())
 
 	b, err = ParseByte8([]byte{0x44, 0x76}, 18)
-	assertStringsEqual(t, "ParseByte8 expected 8 bitst to start at bit 18, but the consent string was only 2 bytes long", err.Error())
+	assertStringsEqual(t, "ParseByte8 expected 8 bits to start at bit 18, but the consent string was only 2 bytes long", err.Error())
 
 	for _, test := range test8Bits {
 		b, err = ParseByte8(test.data, test.offset)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prebid/go-gdpr
 
-go 1.13
+go 1.16
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/buger/jsonparser v0.0.0-20180318095312-2cac668e8456 h1:SnUWpAH4lEUoS86woR12h21VMUbDe+DYp88V646wwMI=
-github.com/buger/jsonparser v0.0.0-20180318095312-2cac668e8456/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -9,6 +7,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vendorconsent/consent20_test.go
+++ b/vendorconsent/consent20_test.go
@@ -47,7 +47,7 @@ func TestInvalidConsentStrings20(t *testing.T) {
 	assertInvalid20(t, "CONciguONcjGKADACHENAACIAC0ta__AACiQABgAAYA", "the consent string encoded a VendorListVersion of 0, but this value must be greater than or equal to 1")
 
 	// Bad BitFields
-	assertInvalid20(t, "CONciguONcjGKADACHENAOCIAC0ta__AACiQAeAA", "a BitField for 60 vendors requires a consent string of 36 bytes. This consent string had 30")
+	assertInvalid20(t, "CONciguONcjGKADACHENAOCIAC0ta__AACiQAeAA", "a BitField for 60 vendors requires a consent string of 37 bytes. This consent string had 30")
 
 	// Bad RangeSections
 	assertInvalid20(t, "CONciguONcjGKADACHENAOCIAC0ta__AACiQABwA", "vendor consent strings using RangeSections require at least 31 bytes. Got 30")                             // This encodes 184 bits

--- a/vendorconsent/tcf2/consent.go
+++ b/vendorconsent/tcf2/consent.go
@@ -2,7 +2,7 @@ package vendorconsent
 
 import (
 	"encoding/base64"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/prebid/go-gdpr/api"
@@ -68,7 +68,7 @@ func Parse(data []byte) (api.VendorConsents, error) {
 	}
 
 	if legitIntStart+16 >= uint(len(data))*8 {
-		return nil, fmt.Errorf("invalid consent data: no legitimate interest start position")
+		return nil, errors.New("invalid consent data: no legitimate interest start position")
 	}
 	if isSet(data, legitIntStart+16) {
 		vendorLegitInts, pubRestrictsStart, err = parseRangeSection(metadata, legIntMaxVend, metadata.vendorLegitimateInterestStart)

--- a/vendorconsent/tcf2/pubrestrict.go
+++ b/vendorconsent/tcf2/pubrestrict.go
@@ -13,7 +13,7 @@ func parsePubRestriction(metadata ConsentMetadata, startbit uint) (*pubRestricti
 	data := metadata.data
 	numRestrictions, err := bitutils.ParseUInt12(data, startbit)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Error on parsing the number of publisher restrictions: %s", err.Error())
+		return nil, 0, fmt.Errorf("Error on parsing the number of publisher restrictions: %w", err)
 	}
 
 	// Parse out the "exceptions" here.
@@ -22,12 +22,12 @@ func parsePubRestriction(metadata ConsentMetadata, startbit uint) (*pubRestricti
 	for j := uint16(0); j < numRestrictions; j++ {
 		restrictData, err := bitutils.ParseByte8(data, currentOffset)
 		if err != nil {
-			return nil, 0, fmt.Errorf("Error on parsing the publisher restriction purpose/type: %s", err.Error())
+			return nil, 0, fmt.Errorf("Error on parsing the publisher restriction purpose/type: %w", err)
 		}
 		currentOffset = currentOffset + 8
 		numEntries, err := bitutils.ParseUInt12(data, currentOffset)
 		if err != nil {
-			return nil, 0, fmt.Errorf("Error on parsing the number of publisher restriction vendor ranges: %s", err.Error())
+			return nil, 0, fmt.Errorf("Error on parsing the number of publisher restriction vendor ranges: %w", err)
 		}
 		currentOffset = currentOffset + 12
 		vendors := make([]rangeConsent, numEntries)


### PR DESCRIPTION
1. I note that one unit tests was failing
2. since the min go version is 1.13 we can use %w to wrap error instead perform string interpolation with %s
3. I fix one typo in one error message
4. In one case I switch from `fmt.Errorf` to `errors.New` since the has a simple string message.